### PR TITLE
Update tier list web scraper to reflect changes in website structure

### DIFF
--- a/LoLAlytics.py
+++ b/LoLAlytics.py
@@ -8,11 +8,12 @@ import csv
 driver = webdriver.Chrome()
 url = "https://lolalytics.com/lol/tierlist/"
 
-file = open("TierlistPatch10.10.csv", 'w')
+file = open("TierlistPatch.csv", 'w')
 writer = csv.writer(file)
 
 driver.get(url)
-WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//*[@id='root']/div[9]/div[2]")))
+local_class = WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//*[@id='root']/div[6]/div/div")))
+element_class = local_class.get_attribute("class")
 
 #List of attributes that are getting scrapped.
 name=[]
@@ -25,14 +26,13 @@ writer.writerow(['Champion Name', 'Win rate', 'Pick Rate'])
 content = driver.page_source
 soup = BeautifulSoup(content)
 
-for row in soup.find('div', 'tierlist wrapper').find_all('div', recursive=False):
+for row in soup.find('div', attrs={'class': element_class}).find_all('div', recursive=False):
     columns = row.find_all('div')
-    name = columns[3].text
-    winRate = columns[8].text
-    pickRate = columns[10].text
+    name = columns[1].text
+    winRate = columns[6].text
+    pickRate = columns[3].text
 
     print(f'{name} - {winRate} - {pickRate}')
     writer.writerow([name, winRate, pickRate])
 
 driver.close()
-


### PR DESCRIPTION
This update adjusts the web scraper to properly scrape data from the latest version of the website. The previous version used XPATH to locate the table, but now the table has moved to a different location and can be found by locating the parent div element. The column indices have also been updated to match the new structure of the table. The output CSV file still contains the same data, with columns for Champion Name, Win rate, and Pick Rate.